### PR TITLE
Converting skill search to regular expressions.

### DIFF
--- a/public/js/skillStats.js
+++ b/public/js/skillStats.js
@@ -237,22 +237,11 @@
                 isCoreSkill: true
             },
             "Angular": {
-                searchPhrases: [
-                    "Angular2",
-                    "Angular 2",
-                    "Angular4",
-                    "Angular 4",
-                    "Angular5",
-                    "Angular 5",
-                    "Angular6",
-                    "Angular 6",
-                    "Angular7",
-                    "Angular 7",
-                    "Angular8",
-                    "Angular 8",
-                    "Angular ",
-                    "Angular,"
-                ],
+                searchPhrases: ['(?=angular(?![-|.|\\s+]?js|\\s*1))'], // Don't mess with this.  It will match Angular on Angular, AngularJS, but not if just Angular.JS is present,
+                isCoreSkill: true
+            },
+            "AngularJS": {
+                searchPhrases: ['AngularJS', 'Angular JS', 'Angular 1', 'Angular1', 'Angular.JS'],
                 isCoreSkill: true
             },
             "Apache ActiveMQ": {
@@ -368,7 +357,7 @@
                 searchPhrases: ["RabbitMQ", "Rabbit MQ"]
             },
             "React": {
-                searchPhrases: ["React"],
+                searchPhrases: ['(?=react(?![-|.|\\s+]?native))'], // Don't mess with this.  It will match React on React, ReactNative, but not if just React Native is present
                 isCoreSkill: true
             },
             "React Native": {

--- a/public/js/tsString.js
+++ b/public/js/tsString.js
@@ -79,12 +79,12 @@
     }
 
     const _containsAny = (string, substrings) => {
-        if (!string) {
+        if (!string || !string.trim || !string.trim()) {
             return false;
         }
 
         return substrings.some((substring) => {
-            if (string.toLowerCase().includes(substring.toLowerCase())) {
+            if (string.trim().match(new RegExp('.*' + substring + '.*', 'i'))) {
                 return true;
             }
             return false;
@@ -92,16 +92,15 @@
     }
 
     const _containsAll = (string, substrings) => {
-        if (!string || !string.trim){
+        if (!string || !string.trim || !string.trim()){
             return false;
         }
 
         let result = true;
-        const lCaseString = string.trim().toLowerCase();
 
         for(let i = 0; i < substrings.length; i++){
             let lookFor = substrings[i];
-            if (lookFor && lookFor.trim && lCaseString.indexOf(lookFor.trim().toLowerCase()) === -1){
+            if (lookFor && string.trim().match(new RegExp('.*' + lookFor + '.*', 'i')) === -1) {
                 result = false;
                 break;
             }


### PR DESCRIPTION
* We can now find "React" with "React Native" but if only "React.Native" exists, it won't falsely state the guy has React too (Same with AngularJS and Angular)